### PR TITLE
feat(endpoint): create movie plugin, routes, and validators

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = (payload) => {
+  return new Movie().save(payload)
+  .then((movie) => {
+    return new Movie({ id: movie.id }).fetch();
+  });
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Controller     = require('./controller');
 const MovieValidator = require('../../../validators/movie');
 
 exports.register = (server, options, next) => {
@@ -8,7 +9,7 @@ exports.register = (server, options, next) => {
     path: '/movies',
     config: {
       handler: (request, reply) => {
-        reply('hello world');
+        reply(Controller.create(request.payload));
       },
       validate: {
         payload: MovieValidator

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,16 +1,21 @@
 'use strict';
 
+const MovieValidator = require('../../../validators/movie');
+
 exports.register = (server, options, next) => {
   server.route([{
-      method: 'POST',
-      path: '/movies',
-      config: {
-        handler: (request, reply) => {
-          reply('hello world');
-        }
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply('hello world');
+      },
+      validate: {
+        payload: MovieValidator
       }
-    }]);
-    
+    }
+  }]);
+
   next();
 
 };

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.register = (server, options, next) => {
+  server.route([{
+      method: 'POST',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply('hello world');
+        }
+      }
+    }]);
+    
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,10 @@ const server = new Hapi.Server({
 server.connection({ port: Config.PORT });
 server.register([
   require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
   require('./plugins/features/movies')
 ], (err) => {
   /* istanbul ignore if */

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,5 +11,14 @@ const server = new Hapi.Server({
 });
 
 server.connection({ port: Config.PORT });
+server.register([
+  require('hapi-bookshelf-serializer'),
+  require('./plugins/features/movies')
+], (err) => {
+  /* istanbul ignore if */
+  if (err) {
+    throw err;
+  }
+});
 
 module.exports = server;

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
+});

--- a/package.json
+++ b/package.json
@@ -9,13 +9,16 @@
   "dependencies": {
     "bookshelf": "^0.12.1",
     "hapi": "14.2.0",
+    "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.1.0",
+    "joi": "12",
     "knex": "^0.14.2",
     "pg": "^7.4.1"
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "eslint": "^1.9.0",
     "eslint-config-lob": "^2.0.0",
+    "eslint": "^1.9.0",
     "generate-changelog": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.2.5",

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
+
+describe('movie controller', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      const payload = { title: 'WALL-E' };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+      });
+    });
+
+  });
+
+});

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(260) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1800
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^2.9.34:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+
 bluebird@^3.0.6, bluebird@^3.4.3, bluebird@^3.4.6:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
@@ -214,7 +218,7 @@ bookshelf@^0.12.1:
     inherits "~2.0.1"
     lodash "^4.13.1"
 
-boom@2.x.x:
+boom@2.x.x, boom@^2.8.0:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
@@ -1137,6 +1141,17 @@ handlebars@^4.0.0, handlebars@^4.0.1:
   optionalDependencies:
     uglify-js "^2.6"
 
+hapi-bookshelf-serializer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-bookshelf-serializer/-/hapi-bookshelf-serializer-2.1.0.tgz#43cbc91db681a2d32bc140d06d8275acdfd29505"
+  dependencies:
+    bluebird "^2.9.34"
+    boom "^2.8.0"
+
+hapi-format-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-format-error/-/hapi-format-error-1.1.0.tgz#28d97f82b40f1b1d1b62b0215eab1cdfe983bbde"
+
 hapi@14.2.0:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-14.2.0.tgz#e4fe2fc182598a0f81e87b41b6be0fbd31c75409"
@@ -1463,6 +1478,12 @@ isemail@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
 
+isemail@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.0.0.tgz#c89a46bb7a3361e1759f8028f9082488ecce3dff"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1518,6 +1539,14 @@ joi@10.x.x:
     hoek "4.x.x"
     isemail "2.x.x"
     items "2.x.x"
+    topo "2.x.x"
+
+joi@12:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+  dependencies:
+    hoek "4.x.x"
+    isemail "3.x.x"
     topo "2.x.x"
 
 joi@9.x.x:
@@ -2364,6 +2393,10 @@ pstree.remy@^1.1.0:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
   dependencies:
     ps-tree "^1.1.0"
+
+punycode@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
### Context:
This is for the __Endpoint Configuration, Validators, Validator Unit Tests, and Controllers__ portion of Miyagi. Before this is completed, we need to have completed the __Model Unit Tests__ portion. Creating the POST /movie endpoint will allow us to create a movie in the database via the controller, and creating the validator will allow us to set constraints for the movie attributes.

### What:
* Created the feature plugin for movie which configures routing and the response for hitting that particular POST endpoint. 
* Created a validator for the movie with specific constraints on the title and release year.
* Set a more specific error response code (from 400 to 422).
* Create a controller to place the response from the POST request into the database.
* Created tests for the validator.

### Why:
* We want to be able to add movies to the database
* We want to make sure that the data we pass to an endpoint is valid
* We need the endpoint response to be more specific
