### PR TITLE
feat(migrations): add name and make title nullable

### DIFF
--- a/db/migrations/20180111132318_add_name_to_movies.js
+++ b/db/migrations/20180111132318_add_name_to_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+  });
+};


### PR DESCRIPTION
### Context:
We need to simulate each step of renaming a column in the Movies table so as to have zero down time for the API when updating the schema. This is step 1: writing a migration to add name and make title nullable.

### What:
* Wrote migration for  adding a "name" column and making the "title" column nullable.

### Why:
* Breaking the schema transformation into several steps allows for no downtime. This will later allow us to update application code seamlessly.
