### PR TITLE
feat(migrations): save name and stop saving title

### DIFF
--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('title') || this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,6 +7,7 @@ exports.create = (payload) => {
     payload.name = payload.title;
     Reflect.deleteProperty(payload, 'title');
   }
+
   return new Movie().save(payload)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,7 +7,7 @@ exports.create = (payload) => {
     payload.name = payload.title;
     Reflect.deleteProperty(payload, 'title');
   }
-  
+
   return new Movie().save(payload)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -7,7 +7,7 @@ exports.create = (payload) => {
     payload.name = payload.title;
     Reflect.deleteProperty(payload, 'title');
   }
-
+  
   return new Movie().save(payload)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
-  if (payload.hasOwnProperty('title')) {
+  if (payload.title) {
     payload.name = payload.title;
     Reflect.deleteProperty(payload, 'title');
   }

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,10 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
+  if (payload.hasOwnProperty('title')) {
+    payload.name = payload.title;
+    Reflect.deleteProperty(payload, 'title');
+  }
   return new Movie().save(payload)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 
 module.exports = Joi.object().keys({
-  title: Joi.string().min(1).max(255).required(),
+  title: Joi.string().min(1).max(255).optional(),
+  name: Joi.string().min(1).max(255).optional(),
   release_year: Joi.number().integer().min(1878).max(9999).optional()
-});
+}).xor("title", "name");

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -6,4 +6,4 @@ module.exports = Joi.object().keys({
   title: Joi.string().min(1).max(255).optional(),
   name: Joi.string().min(1).max(255).optional(),
   release_year: Joi.number().integer().min(1878).max(9999).optional()
-}).xor("title", "name");
+}).xor('title', 'name');

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -6,8 +6,22 @@ describe('movie model', () => {
 
   describe('serialize', () => {
 
-    it('includes all of the necessary fields', () => {
-      const movie = Movie.forge().serialize();
+    const titleField = 'title';
+
+    it('includes all of the necessary fields with name field', () => {
+
+      const movie = Movie.forge().serialize({ name: titleField });
+
+      expect(movie).to.have.all.keys([
+        'id',
+        'title',
+        'release_year',
+        'object'
+      ]);
+    });
+
+    it('includes all of the necessary fields with title field', () => {
+      const movie = Movie.forge().serialize({ title: titleField });
 
       expect(movie).to.have.all.keys([
         'id',

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -20,7 +20,7 @@ describe('movie model', () => {
     it('has a title field with a name input', () => {
       const titleField = 'title';
       const movie = Movie.forge({ name: titleField }).serialize();
-      
+
       expect(movie.title).to.eql(titleField);
     });
 

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -21,6 +21,7 @@ describe('movie model', () => {
     });
 
     it('includes all of the necessary fields with title field', () => {
+
       const movie = Movie.forge().serialize({ title: titleField });
 
       expect(movie).to.have.all.keys([

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -7,8 +7,8 @@ describe('movie model', () => {
   describe('serialize', () => {
 
     it('includes all of the necessary fields', () => {
-
       const movie = Movie.forge().serialize();
+
       expect(movie).to.have.all.keys([
         'id',
         'title',
@@ -18,9 +18,9 @@ describe('movie model', () => {
     });
 
     it('has a title field with a name input', () => {
-
       const titleField = 'title';
       const movie = Movie.forge({ name: titleField }).serialize();
+      
       expect(movie.title).to.eql(titleField);
     });
 

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -6,12 +6,9 @@ describe('movie model', () => {
 
   describe('serialize', () => {
 
-    const titleField = 'title';
+    it('includes all of the necessary fields', () => {
 
-    it('includes all of the necessary fields with name field', () => {
-
-      const movie = Movie.forge().serialize({ name: titleField });
-
+      const movie = Movie.forge().serialize();
       expect(movie).to.have.all.keys([
         'id',
         'title',
@@ -20,16 +17,11 @@ describe('movie model', () => {
       ]);
     });
 
-    it('includes all of the necessary fields with title field', () => {
+    it('has a title field with a name input', () => {
 
-      const movie = Movie.forge().serialize({ title: titleField });
-
-      expect(movie).to.have.all.keys([
-        'id',
-        'title',
-        'release_year',
-        'object'
-      ]);
+      const titleField = 'title';
+      const movie = Movie.forge({ name: titleField }).serialize();
+      expect(movie.title).to.eql(titleField);
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -8,6 +8,7 @@ describe('movie controller', () => {
   describe('create', () => {
 
     it('creates a movie with title attribute', () => {
+
       const payload = { title: 'WALL-E' };
       return Controller.create(payload)
       .then((movie) => {
@@ -21,6 +22,7 @@ describe('movie controller', () => {
     });
 
     it('creates a movie with name attribute', () => {
+
       const payload = { name: 'WALL-E' };
       return Controller.create(payload)
       .then((movie) => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -8,12 +8,11 @@ describe('movie controller', () => {
   describe('create', () => {
 
     it('creates a movie with title attribute', () => {
-
       const payload = { title: 'WALL-E' };
+
       return Controller.create(payload)
       .then((movie) => {
         expect(movie.get('name')).to.eql(payload.name);
-
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {
@@ -22,12 +21,11 @@ describe('movie controller', () => {
     });
 
     it('creates a movie with name attribute', () => {
-
       const payload = { name: 'WALL-E' };
+
       return Controller.create(payload)
       .then((movie) => {
         expect(movie.get('name')).to.eql(payload.name);
-
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,8 +7,21 @@ describe('movie controller', () => {
 
   describe('create', () => {
 
-    it('creates a movie', () => {
+    it('creates a movie with title attribute', () => {
       const payload = { title: 'WALL-E' };
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('name')).to.eql(payload.name);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('name')).to.eql(payload.name);
+      });
+    });
+
+    it('creates a movie with name attribute', () => {
+      const payload = { name: 'WALL-E' };
       return Controller.create(payload)
       .then((movie) => {
         expect(movie.get('name')).to.eql(payload.name);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -9,15 +9,14 @@ describe('movie controller', () => {
 
     it('creates a movie', () => {
       const payload = { title: 'WALL-E' };
-
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(payload.name);
 
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(payload.name);
       });
     });
 

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -12,7 +12,6 @@ describe('movie validator', () => {
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].message).includes('[title, name]');
       expect(result.error.details[0].path[0]).to.eql(undefined);
       expect(result.error.details[0].type).to.eql('object.missing');
     });
@@ -24,7 +23,6 @@ describe('movie validator', () => {
       };
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].message).includes('contains a conflict between exclusive peers [title, name]');
       expect(result.error.details[0].path[0]).to.eql(undefined);
       expect(result.error.details[0].type).to.eql('object.xor');
     });

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -6,14 +6,15 @@ const MovieValidator = require('../../lib/validators/movie');
 
 describe('movie validator', () => {
 
-  describe('title', () => {
+  describe('title or name', () => {
 
     it('is required', () => {
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].path[0]).to.eql('title');
-      expect(result.error.details[0].type).to.eql('any.required');
+      expect(result.error.details[0].message).includes('[title, name]');
+      expect(result.error.details[0].path[0]).to.eql(undefined);
+      expect(result.error.details[0].type).to.eql('object.missing');
     });
 
     it('is less than 255 characters', () => {

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -12,7 +12,7 @@ describe('movie validator', () => {
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].path[0]).to.eql(undefined);
+      expect(result.error.details[0].context.peers).to.contain.members(['title', 'name']);
       expect(result.error.details[0].type).to.eql('object.missing');
     });
 
@@ -23,7 +23,7 @@ describe('movie validator', () => {
       };
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].path[0]).to.eql(undefined);
+      expect(result.error.details[0].context.peers).to.contain.members(['title', 'name']);
       expect(result.error.details[0].type).to.eql('object.xor');
     });
 

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -27,6 +27,27 @@ describe('movie validator', () => {
 
   });
 
+  describe('title and name', () => {
+
+    it('are not set at the same time', () => {
+      const payload = { title: 'WALL-E', name: 'WALL-E' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].message).includes('contains a conflict between exclusive peers [title, name]');
+      expect(result.error.details[0].path[0]).to.eql(undefined);
+      expect(result.error.details[0].type).to.eql('object.xor');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(260) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
   describe('release_year', () => {
 
     it('is after 1878', () => {

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -9,7 +9,6 @@ describe('movie validator', () => {
   describe('title and name', () => {
 
     it('has one or the other', () => {
-
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
@@ -19,8 +18,10 @@ describe('movie validator', () => {
     });
 
     it('are not set at the same time', () => {
-
-      const payload = { title: 'WALL-E', name: 'WALL-E' };
+      const payload = {
+        title: 'WALL-E',
+        name: 'WALL-E'
+      };
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].message).includes('contains a conflict between exclusive peers [title, name]');
@@ -29,7 +30,6 @@ describe('movie validator', () => {
     });
 
     it('is less than 255 characters', () => {
-
       const payload = { title: 'a'.repeat(260) };
       const result = Joi.validate(payload, MovieValidator);
 
@@ -42,7 +42,6 @@ describe('movie validator', () => {
   describe('release_year', () => {
 
     it('is after 1878', () => {
-
       const payload = {
         title: 'foo',
         release_year: 1800
@@ -54,7 +53,6 @@ describe('movie validator', () => {
     });
 
     it('is limited to 4 digits', () => {
-
       const payload = {
         title: 'foo',
         release_year: 12345

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -6,9 +6,10 @@ const MovieValidator = require('../../lib/validators/movie');
 
 describe('movie validator', () => {
 
-  describe('title or name', () => {
+  describe('title and name', () => {
 
-    it('is required', () => {
+    it('has one or the other', () => {
+
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
@@ -17,19 +18,8 @@ describe('movie validator', () => {
       expect(result.error.details[0].type).to.eql('object.missing');
     });
 
-    it('is less than 255 characters', () => {
-      const payload = { title: 'a'.repeat(260) };
-      const result = Joi.validate(payload, MovieValidator);
-
-      expect(result.error.details[0].path[0]).to.eql('title');
-      expect(result.error.details[0].type).to.eql('string.max');
-    });
-
-  });
-
-  describe('title and name', () => {
-
     it('are not set at the same time', () => {
+
       const payload = { title: 'WALL-E', name: 'WALL-E' };
       const result = Joi.validate(payload, MovieValidator);
 
@@ -39,6 +29,7 @@ describe('movie validator', () => {
     });
 
     it('is less than 255 characters', () => {
+
       const payload = { title: 'a'.repeat(260) };
       const result = Joi.validate(payload, MovieValidator);
 
@@ -51,6 +42,7 @@ describe('movie validator', () => {
   describe('release_year', () => {
 
     it('is after 1878', () => {
+
       const payload = {
         title: 'foo',
         release_year: 1800
@@ -62,6 +54,7 @@ describe('movie validator', () => {
     });
 
     it('is limited to 4 digits', () => {
+
       const payload = {
         title: 'foo',
         release_year: 12345


### PR DESCRIPTION
### Context:
We need to simulate each step of renaming a column in the Movies table so as to have zero down time for the API when updating the schema. This is step 2: update the application code to save name and stop saving title.

### What:
* Update application code to be compatible with the 'name' column in the database, e.g. submitting a movie request to the /POST movie endpoint with a title field and then querying for that using the db's 'name' column
* Make sure that POST requests no longer save to the 'title' column in the database
* Add functionality to optionally submit a request to the /POST movie endpoint with the 'name' field instead of the 'title' field while making one of the two required

### Why:
We want the API to still be usable (with zero downtime) when updating the schema and the application code. This will ensure that the codebase and the database are compatible with previous versions and newer ones.