### PR TITLE
feat(migrations): backfill null values of name

### DIFF
--- a/db/migrations/20180116140243_backfill_movies_name.js
+++ b/db/migrations/20180116140243_backfill_movies_name.js
@@ -4,6 +4,6 @@ exports.up = (Knex) => {
   return Knex.raw('UPDATE movies SET name = title');
 };
 
-exports.down = (Promise) => {
+exports.down = (Knex, Promise) => {
   return Promise.resolve();
 };

--- a/db/migrations/20180116140243_backfill_movies_name.js
+++ b/db/migrations/20180116140243_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Promise) => {
+  return Promise.resolve();
+};


### PR DESCRIPTION
### Context:
We need to simulate each step of renaming a column in the Movies table so as to have zero down time for the API when updating the schema. This is step 3: write a migration to backfill all the null values of the name column.

### What:
* Create a new migration to backfill the null values of the name column in the database.

### Why:
We plan to delete the title column later on. Before we do that, however, we must copy over the values from the title column to the name column through the backfill process specified in the migration.