### PR TITLE
feat(migrations): add not null constraint to name and drop title

### DIFF
--- a/db/migrations/20180117105626_drop_title_from_movies.js
+++ b/db/migrations/20180117105626_drop_title_from_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+  });
+};


### PR DESCRIPTION
### Context:
We need to simulate each step of renaming a column in the Movies table so as to have zero down time for the API when updating the schema. This is step 4: write a migration to add a not null constraint to name and drop the title column.

### What:
Create a new migration to drop the title column and make the name column not null.

### Why:
In order to have zero downtime overall, we first change the codebase to make it compatible with the old schema and the new schema, and then we run the migration after the codebase has been changed. This ensures that we complete our original goal of renaming the 'title' column to 'name'. 