### PR TITLE
feat(migrations): add locations and movies_locations migration

### DIFF
--- a/db/migrations/20180118003102_create_locations.js
+++ b/db/migrations/20180118003102_create_locations.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.createTable('locations', (table) => {
+    table.increments('id').primary();
+    table.text('name').notNullable();
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.dropTable('locations');
+};

--- a/db/migrations/20180119020158_create_locations_movies.js
+++ b/db/migrations/20180119020158_create_locations_movies.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.up = (Knex) => {
-  return Knex.schema.createTable('movies_locations', (table) => {
+  return Knex.schema.createTable('locations_movies', (table) => {
     table.increments('id').primary();
     table.integer('movie_id').references('movies.id');
     table.integer('location_id').references('locations.id');
@@ -9,5 +9,5 @@ exports.up = (Knex) => {
 };
 
 exports.down = (Knex) => {
-  return Knex.schema.dropTable('movies_locations');
+  return Knex.schema.dropTable('locations_movies');
 };

--- a/db/migrations/20180119020158_create_movies_locations.js
+++ b/db/migrations/20180119020158_create_movies_locations.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.createTable('movies_locations', (table) => {
+    table.increments('id').primary();
+    table.integer('movie_id').references('movies.id');
+    table.integer('location_id').references('locations.id');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.dropTable('movies_locations');
+};


### PR DESCRIPTION
### Context:
We added these two migrations so that we can associate locations with movies in a many to many relationship.

### What:
* Create migration for creating the locations table
* Create migration for creating the movies_locations table

### Why:
(Correct me if I'm wrong here): we don't want our code to break anything, so we submit a PR for the migrations first. The migrations currently don't necessitate code changes, so there is no need for the code changes to be applicable to the old and new schemas like what was previously needed for zero downtime.